### PR TITLE
fix PATH format

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -89,7 +89,7 @@ ifeq ($(PLATFORM),PLATFORM_WEB)
     CLANG_PATH          = $(EMSDK_PATH)/upstream/bin
     PYTHON_PATH         = $(EMSDK_PATH)/python/3.9.2-1_64bit
     NODE_PATH           = $(EMSDK_PATH)/node/14.15.5_64bit/bin
-    export PATH         = $(EMSDK_PATH);$(EMSCRIPTEN_PATH);$(CLANG_PATH);$(NODE_PATH);$(PYTHON_PATH):$$(PATH)
+    export PATH         = $(EMSDK_PATH):$(EMSCRIPTEN_PATH):$(CLANG_PATH):$(NODE_PATH):$(PYTHON_PATH):$(shell printenv PATH)
 endif
 
 # Define default C compiler: CC


### PR DESCRIPTION
I'd been getting an error on building on PLATFORM_WEB
```
$ make PLATFORM=PLATFORM_WEB -B
make raylib_game
make: make: No such file or directory
make: *** [Makefile:311: all] Error 127
```

here's the path that was being produced in the Makefile
```
$ make PLATFORM=PLATFORM_WEB -B other
~/.emsdk;~/.emsdk/upstream/emscripten;~/.emsdk/upstream/bin;~/.emsdk/node/14.15.5_64bit/bin;:$(PATH)
```

here's the path now (which looks better)
```
$ make PLATFORM=PLATFORM_WEB -B other
~/.emsdk:~/.emsdk/upstream/emscripten:~/.emsdk/upstream/bin:~/.emsdk/node/14.15.5_64bit/bin:/home/byoung/.emsdk/upstream/emscripten:/home/byoung/.emsdk:/home/byoung/.volta/bin:/home/byoung/.local/bin:/home/byoung/bin:/home/byoung/.cargo/bin:/usr/local/bin:/usr/bin:/bin:/usr/local/games:/usr/games:/usr/local/go/bin
```

the `$$PATH` append was breaking my PATH, but I also noticed the separators used here were `;`, fixed that as well, now my builds work as expected.

The builds also worked with the `;`, but I think that's only because my PATH was also properly set up outside the Makefile.